### PR TITLE
fix: Reset connect button text after wallet disconnect

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -315,7 +315,9 @@ class CryptoPaymentApp {
 
         walletAddress.textContent = 'Not Connected';
 
-        // Show connect button, hide disconnect button
+        // Show connect button, hide disconnect button and reset connect button state
+        connectBtn.textContent = 'Connect Phantom Wallet';
+        connectBtn.disabled = false;
         connectBtn.style.display = 'block';
         disconnectBtn.style.display = 'none';
 


### PR DESCRIPTION
## Summary
Fixed bug where the connect button showed incorrect text after wallet disconnect. The button now properly displays 'Connect Phantom Wallet' text.

## Problem
When user clicked the Disconnect button, the wallet would disconnect correctly but the connect button would appear with incorrect text ('Connecting...' or previous state text) instead of the initial 'Connect Phantom Wallet' text.

## Root Cause
The `handleWalletDisconnected()` method was showing the connect button but not resetting its text and disabled state to the initial values.

## Solution
Updated `handleWalletDisconnected()` to:
- Reset button text to 'Connect Phantom Wallet'
- Reset disabled state to false
- Properly manage button visibility

## Changes
- Modified `src/app.js` handleWalletDisconnected() method
- Added 2 lines to reset button state

## Testing
✅ All 206 tests passing
✅ Button state transitions verified
✅ UI properly resets to initial state after disconnect

## User Impact
- Users now see correct button text after disconnect
- Button is properly enabled for reconnection
- Clear initial state indication

Resolves #28

🤖 Generated with Claude Code