### PR TITLE
fix: Properly restore button states on connection/disconnection errors

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -209,8 +209,15 @@ class CryptoPaymentApp {
             this.showStatus('error', 'Failed to connect wallet: ' + error.message);
 
             const connectBtn = document.getElementById('connectWallet');
+            const disconnectBtn = document.getElementById('disconnectWallet');
+
+            // Restore connect button to initial state
             connectBtn.disabled = false;
             connectBtn.textContent = 'Connect Phantom Wallet';
+            connectBtn.style.display = 'block';
+
+            // Hide disconnect button
+            disconnectBtn.style.display = 'none';
         }
     }
 
@@ -260,8 +267,15 @@ class CryptoPaymentApp {
             this.showStatus('error', 'Failed to disconnect wallet: ' + error.message);
 
             const disconnectBtn = document.getElementById('disconnectWallet');
+            const connectBtn = document.getElementById('connectWallet');
+
+            // Restore disconnect button to clickable state
             disconnectBtn.disabled = false;
             disconnectBtn.textContent = 'Disconnect';
+            disconnectBtn.style.display = 'block';
+
+            // Keep connect button hidden
+            connectBtn.style.display = 'none';
         }
     }
 


### PR DESCRIPTION
## Summary
Fixed issue where connect/disconnect buttons were not properly visible or in correct state when connection or disconnection failed.

## Problem
When wallet connection or disconnection encountered an error:
- Connect button text and enabled state were reset
- But button visibility was not properly managed
- Could cause confusion about current wallet connection state

## Solution
Updated both error handlers to explicitly manage button visibility:

### connectWallet() Error Handler
- Explicitly shows connect button (`display: block`)
- Hides disconnect button (`display: none`)
- Resets button text to 'Connect Phantom Wallet'
- Resets button enabled state

### disconnectWallet() Error Handler
- Explicitly shows disconnect button (`display: block`)
- Keeps connect button hidden (`display: none`)
- Resets button text to 'Disconnect'
- Resets button enabled state

## Testing
✅ All 206 tests passing
✅ Button states properly restored on errors
✅ UI correctly reflects wallet connection state

## Impact
- Better error recovery
- Clear UI state on connection failures
- Users can retry connection/disconnection

Resolves #30

🤖 Generated with Claude Code